### PR TITLE
Mztdn 155/remove first visit dialog

### DIFF
--- a/components/modal/ModalContainer.vue
+++ b/components/modal/ModalContainer.vue
@@ -9,7 +9,7 @@ import {
   isFavouritedBoostedByDialogOpen,
   isKeyboardShortcutsDialogOpen,
   isMediaPreviewOpen,
-  isPreviewHelpOpen,
+  // isPreviewHelpOpen,
   isPublishDialogOpen,
   isSigninDialogOpen,
 } from '~/composables/dialog'
@@ -57,9 +57,9 @@ function handleFavouritedBoostedByClose() {
     <ModalDialog v-model="isSigninDialogOpen" py-4 px-8 max-w-125>
       <UserSignIn />
     </ModalDialog>
-    <ModalDialog v-model="isPreviewHelpOpen" keep-alive max-w-125>
+    <!-- <ModalDialog v-model="isPreviewHelpOpen" keep-alive max-w-125>
       <HelpPreview @close="closePreviewHelp()" />
-    </ModalDialog>
+    </ModalDialog> -->
     <ModalDialog
       v-model="isPublishDialogOpen"
       max-w-180 flex

--- a/pages/settings/about/index.vue
+++ b/pages/settings/about/index.vue
@@ -51,12 +51,12 @@ function handleShowCommit() {
 
     <div h-1px bg-border my2 />
 
-    <SettingsItem
+    <!-- <SettingsItem
       :text="$t('nav.show_intro')"
       icon="i-ri:article-line"
       cursor-pointer large
       @click="openPreviewHelp"
-    />
+    /> -->
 
     <SettingsItem
       text="Mastodon"


### PR DESCRIPTION
Removes Elk Preview dialog that displays on first visit.  Also removes related settings control that triggers the same dialog.  

Comment used to disable dialog in case we want to re-enable with Mozilla.social branded welcome or similar.